### PR TITLE
Add pre-commit-hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: beancount-black
+  description: beancount-black
+  name: beancount-black
+  entry: bean-black -n
+  language: python
+  files: \.(beancount|bean)$


### PR DESCRIPTION
Hi!

Thanks for this repo! I thought of adding a pre-commit hook to make it run whenever someone commits a beancount file to git.

Example usage

Create a `.pre-commit-config.yaml `
Note: the rev and repo link would change
```yaml
repos:
  - repo: https://github.com/jtmiclat/beancount-black # to be changed to https://github.com/LaunchPlatform/beancount-black
    rev: b1e97d9 
    hooks:
      - id: beancount-black
```

Run `pre-commit run -a ` or install the hook using `pre-commit install`

